### PR TITLE
Use init instead of initModulesPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var app_modules = require('app_modules');
 // IRL, compute the following paths dynamically:
 
 // initialize the library (this creates an app_modules dir in your project root):
-app_modules.initModulesPath('/path/to/my/project/');   
+app_modules.init('/path/to/my/project/');   
 
 // make src/ available as a module named app:
 app_modules.addModule('app', '/path/to/my/project/src/'); // app_modules/app now points to src/
@@ -54,10 +54,10 @@ Initialize app_modules with dynamically computed paths:
 var app_modules = require('app_modules');
 var path = require('path');
 
-app_modules.initModulesPath(path.resolve(__dirname, '..'));  // path of project root
+app_modules.init(path.resolve(__dirname, '..'));  // path of project root
 app_modules.addModule('app', __dirname);  // dynamically link app to either src/ or lib/
 
-// ... continue loading 
+// ... continue loading
 ```
 
 Now you can write:
@@ -73,12 +73,12 @@ This library uses an old but unofficial method `_initPaths` defined on the `Modu
 
 ## API
 
-### initModulesPath
+### init
 
 Ensures a directory exists in the project root and adds it to the NODE_PATH.  Directories in this folder will be accessible as modules.
 
 ```javascript
-initModulesPath(projectRoot, app_modules_dirname)
+init(projectRoot, app_modules_dirname)
 // where
 // projectRoot - path to the root dir of your node project
 // app_modules_dirname - defaults to 'app_modules'

--- a/index.js
+++ b/index.js
@@ -41,6 +41,10 @@ function addModuleRequirePath(dir) {
 
 module.exports = {
   initModulesPath(projectRoot, modulesDirectory) {
+    console.log('app_modules.initModulesPath is deprecated.  Use app_modules.init'); // eslint-disable-line
+    return this.init(projectRoot, modulesDirectory);
+  },
+  init(projectRoot, modulesDirectory) {
     modulesDirectory = modulesDirectory || 'app_modules';
     moduleRequirePath = path.resolve(projectRoot, modulesDirectory);
     addModuleRequirePath(moduleRequirePath);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app_modules",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Make app subdirectories appear as custom-named modules to require/import",
   "main": "index.js",
   "scripts": {

--- a/test.index.js
+++ b/test.index.js
@@ -37,27 +37,27 @@ describe('app_modules', function () {
     rimraf(testDir);
   });
 
-  context('initModulesPath', function () {
+  context('init', function () {
     it('should create an directory with the specify name', function () {
-      app_modules.initModulesPath(testDir, 'testing');
+      app_modules.init(testDir, 'testing');
       expect(fs.statSync(path.resolve(testDir, 'testing')).isDirectory()).to.be.ok;
     });
 
     it('should create an app_modules directory if name is not specified', function () {
-      app_modules.initModulesPath(testDir);
+      app_modules.init(testDir);
       expect(fs.statSync(path.resolve(testDir, 'app_modules')).isDirectory()).to.be.ok;
     });
   });
 
   context('addModule', function () {
     it('should add a symlink to the app_modules directory', function () {
-      app_modules.initModulesPath(testDir);
+      app_modules.init(testDir);
       app_modules.addModule('xyz', path.resolve(__dirname, 'testModules'));
       expect(fs.lstatSync(path.resolve(testDir, 'app_modules/xyz')).isSymbolicLink()).to.be.ok;
     });
 
     it('should add a symlink that is accessible by require', function () {
-      app_modules.initModulesPath(testDir);
+      app_modules.init(testDir);
       app_modules.addModule('xyz', path.resolve(__dirname, 'testModules'));
       expect(require('xyz/foo/bar')).to.equal('baz!');
     });


### PR DESCRIPTION
* initModulesPath now emits a deprecation warning
* init method has the same behavior